### PR TITLE
Fix issues in OpenShift support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
 # multi-stage build
+FROM debian:9 AS proot
+RUN apt-get update && apt-get install -q -y build-essential git libseccomp-dev libtalloc-dev \
+ # deps for PERSISTENT_CHOWN extension
+ libprotobuf-c-dev libattr1-dev
+RUN git clone https://github.com/rootless-containers/PRoot.git \
+  && cd PRoot \
+  && git checkout 081bb63955eb4378e53cf4d0eb0ed0d3222bf66e \
+  && cd src \
+  && make && mv proot / && make clean
+
+FROM golang:1.9-alpine AS runc
+RUN apk add --no-cache git g++ linux-headers
+RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc \
+  && cd /go/src/github.com/opencontainers/runc \
+  && git checkout -q e6516b3d5dc780cb57a976013c242a9a93052543 \
+  && go build -o /runc .
 
 #
 # build stage
@@ -19,15 +35,24 @@ RUN go get github.com/google/gops
 #
 # Start a new stage from scratch
 #
-FROM alpine
+FROM alpine:3.7
+RUN adduser -u 1000 -D user
+COPY --from=proot /proot /home/user/.runrootless/runrootless-proot
+COPY --from=runc /runc /home/user/bin/runc
+
 RUN apk --no-cache add ca-certificates
-WORKDIR /app
-COPY --from=builder /root/src/pulsar-heartbeat /app/
+COPY --from=builder /root/src/pulsar-heartbeat /home/user
 
 # a kesque cert but it can overwritten by mounting the same path ca-bundle.crt
 COPY --from=builder /root/config/kesque-pulsar.cert /etc/ssl/certs/ca-bundle.crt
 
 # Copy debug tools
-COPY --from=builder /go/bin/gops /app/gops
+COPY --from=builder /go/bin/gops /home/user/gops
+RUN mkdir /home/user/run
+RUN chown -R user /home/user
+USER user
+WORKDIR /home/user
+ENV PATH=/home/user/bin:$PATH
+ENV XDG_RUNTIME_DIR=/home/user/run
 
 ENTRYPOINT ./pulsar-heartbeat ./runtime.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,10 @@ COPY --from=builder /root/config/kesque-pulsar.cert /etc/ssl/certs/ca-bundle.crt
 # Copy debug tools
 COPY --from=builder /go/bin/gops /home/user/gops
 RUN mkdir /home/user/run
-RUN chown -R user /home/user
+RUN chown -R user:0 /home/user && chmod g=u /home/user
 USER user
 WORKDIR /home/user
+ENV HOME=/home/user
 ENV PATH=/home/user/bin:$PATH
 ENV XDG_RUNTIME_DIR=/home/user/run
-
 ENTRYPOINT ./pulsar-heartbeat ./runtime.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,5 @@ WORKDIR /home/user
 ENV HOME=/home/user
 ENV PATH=/home/user/bin:$PATH
 ENV XDG_RUNTIME_DIR=/home/user/run
-ENTRYPOINT ./pulsar-heartbeat ./runtime.yml
+ENV PULSAR_OPS_MONITOR_CFG=/config/runtime.yml
+ENTRYPOINT ./pulsar-heartbeat

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: push
 #
 # Docker tag with v prefix to differentiate the official release build, triggered by git tagging
 #
-TAG ?= v0.0.5
+TAG ?= v0.0.6
 PREFIX ?= datastax/pulsar-heartbeat
 
 container:


### PR DESCRIPTION
This PR contains changes on top of PR #12 to support OpenShift.

- support arbitrary user id that OpenShift uses by default. Achieved by these lines in Dockerfile
```
RUN chown -R user:0 /home/user && chmod g=u /home/user
ENV HOME=/home/user
```
- fix issue in loading configuration file. Use `ENV PULSAR_OPS_MONITOR_CFG=/config/runtime.yml` to specify config file.



