### PR TITLE
remove default trust store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,6 @@ COPY --from=runc --chown=1000:0 /runc /home/user/bin/runc
 RUN apk --no-cache add ca-certificates
 COPY --from=builder --chown=1000:0 /root/src/pulsar-heartbeat /home/user
 
-# a kesque cert but it can overwritten by mounting the same path ca-bundle.crt
-COPY --from=builder --chown=1000:0 /root/config/kesque-pulsar.cert /etc/ssl/certs/ca-bundle.crt
-
 # Copy debug tools
 COPY --from=builder --chown=1000:0 /go/bin/gops /home/user/gops
 RUN mkdir /home/user/run && chmod g=u /home/user/run

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: push
 #
 # Docker tag with v prefix to differentiate the official release build, triggered by git tagging
 #
-TAG ?= v0.0.6
+TAG ?= v0.0.7
 PREFIX ?= datastax/pulsar-heartbeat
 
 container:

--- a/src/cfg/pulsar-latency.go
+++ b/src/cfg/pulsar-latency.go
@@ -69,11 +69,12 @@ func GetPulsarClient(pulsarURL, tokenStr string) (pulsar.Client, error) {
 		}
 
 		if strings.HasPrefix(pulsarURL, "pulsar+ssl://") {
-			trustStore := util.AssignString(GetConfig().TrustStore, "/etc/ssl/certs/ca-bundle.crt")
-			if trustStore == "" {
-				return nil, fmt.Errorf("fatal error: missing trustStore while pulsar+ssl tls is enabled")
+			trustStore := GetConfig().TrustStore
+			if trustStore != "" {
+				clientOpt.TLSTrustCertsFilePath = trustStore
+			} else {
+				log.Warn("missing trustStore while pulsar+ssl tls is enabled")
 			}
-			clientOpt.TLSTrustCertsFilePath = trustStore
 		}
 
 		pulsarClient, err := pulsar.NewClient(clientOpt)
@@ -325,7 +326,7 @@ func expectedMessage(payload, expected string) string {
 }
 
 func testPartitionTopic(clusterName, token string, cfg TopicCfg) {
-	trustStore := util.AssignString(cfg.TrustStore, GetConfig().TrustStore, "/etc/ssl/certs/ca-bundle.crt")
+	trustStore := util.AssignString(cfg.TrustStore, GetConfig().TrustStore)
 	testName := "partition-topics-test"
 	component := clusterName + "-" + testName
 	pt, err := getPartition(cfg, token, trustStore)


### PR DESCRIPTION
Remove default trust store. Most well known CA should be trusted. TrustStore can still be overwritten in config yaml or env as option.