### PR TITLE
simplify pubsub downtime as calculation

### DIFF
--- a/src/cfg/config.go
+++ b/src/cfg/config.go
@@ -105,21 +105,22 @@ type PulsarAdminRESTCfg struct {
 
 // TopicCfg is topic configuration
 type TopicCfg struct {
-	Name               string         `json:"name"`
-	ClusterName        string         `json:"clusterName"` // used for broker monitoring if specified
-	Token              string         `json:"token"`
-	TrustStore         string         `json:"trustStore"`
-	NumberOfPartitions int            `json:"numberOfPartitions"`
-	LatencyBudgetMs    int            `json:"latencyBudgetMs"`
-	PulsarURL          string         `json:"pulsarUrl"`
-	AdminURL           string         `json:"adminUrl"`
-	TopicName          string         `json:"topicName"`
-	OutputTopic        string         `json:"outputTopic"`
-	IntervalSeconds    int            `json:"intervalSeconds"`
-	ExpectedMsg        string         `json:"expectedMsg"`
-	PayloadSizes       []string       `json:"payloadSizes"`
-	NumOfMessages      int            `json:"numberOfMessages"`
-	AlertPolicy        AlertPolicyCfg `json:"AlertPolicy"`
+	Name                    string         `json:"name"`
+	ClusterName             string         `json:"clusterName"` // used for broker monitoring if specified
+	Token                   string         `json:"token"`
+	TrustStore              string         `json:"trustStore"`
+	NumberOfPartitions      int            `json:"numberOfPartitions"`
+	LatencyBudgetMs         int            `json:"latencyBudgetMs"`
+	PulsarURL               string         `json:"pulsarUrl"`
+	AdminURL                string         `json:"adminUrl"`
+	TopicName               string         `json:"topicName"`
+	OutputTopic             string         `json:"outputTopic"`
+	IntervalSeconds         int            `json:"intervalSeconds"`
+	ExpectedMsg             string         `json:"expectedMsg"`
+	PayloadSizes            []string       `json:"payloadSizes"`
+	NumOfMessages           int            `json:"numberOfMessages"`
+	AlertPolicy             AlertPolicyCfg `json:"AlertPolicy"`
+	DowntimeTrackerDisabled bool           `json:"downtimeTrackerDisabled"`
 }
 
 // WsConfig is configuration to monitor WebSocket pub sub latency

--- a/src/cfg/incident_test.go
+++ b/src/cfg/incident_test.go
@@ -189,6 +189,21 @@ func TestIncidentAlertMovingWindowPolicy(t *testing.T) {
 	assert(t, !trackIncident("component3", "time out message", "save me description", &policy), "")
 }
 
+func TestIsDowntimeReporting(t *testing.T) {
+	topicCfg := TopicCfg{}
+	assert(t, !isDowntimeReporting(topicCfg), "")
+	topicCfg.NumberOfPartitions = 1
+	topicCfg.ClusterName = "cluster1"
+	assert(t, isDowntimeReporting(topicCfg), "")
+
+	topicCfg.NumberOfPartitions = 2
+	assert(t, !isDowntimeReporting(topicCfg), "")
+
+	topicCfg.NumberOfPartitions = 1
+	topicCfg.ClusterName = ""
+	assert(t, !isDowntimeReporting(topicCfg), "")
+}
+
 // assert fails the test if the condition is false.
 func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 	if !condition {


### PR DESCRIPTION
- Simplify and make downtime reporting more robust
- Report pubsub downtime as a gauge
- Report downtime every topic pubsub interval 
- Value of downtime matches the topic pubsub interval or 0 (no downtime)