### PR TITLE
Support for tokens fetched at runtime using OAuth2 client credentials flow

### DIFF
--- a/config/runtime-template.yml
+++ b/config/runtime-template.yml
@@ -4,6 +4,10 @@ prometheusConfig:
   exposeMetrics: true
 slackConfig:
   alertUrl: required
+tokenOAuthConfig:
+  ClientID: "example-client"
+  ClientSecret: "example-client-secret"
+  TokenURL: "<token-endpoint of oauth2 provider>"
 sitesConfig:
   sites:
 opsGenieConfig:

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b // indirect
 	k8s.io/api v0.18.5

--- a/src/cfg/broker-stats.go
+++ b/src/cfg/broker-stats.go
@@ -257,7 +257,7 @@ func TestBrokers(topicCfg TopicCfg) error {
 	}
 	name := topicCfg.ClusterName + "-brokers"
 
-	tokenSupplier := util.TokenSupplierWithOverride(topicCfg.Token, Config.TokenSupplier())
+	tokenSupplier := util.TokenSupplierWithOverride(topicCfg.Token, GetConfig().TokenSupplier())
 
 	intervalDuration := 10 * time.Second
 	if topicCfg.IntervalSeconds > 20 {

--- a/src/cfg/broker-stats.go
+++ b/src/cfg/broker-stats.go
@@ -46,14 +46,20 @@ const (
 )
 
 // GetBrokers gets a list of brokers and ports
-func GetBrokers(restBaseURL, clusterName, token string) ([]string, error) {
+func GetBrokers(restBaseURL, clusterName string, tokenSupplier func()(string, error)) ([]string, error) {
 	brokersURL := util.SingleSlashJoin(restBaseURL, "admin/v2/brokers/"+clusterName)
 	newRequest, err := http.NewRequest(http.MethodGet, brokersURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	newRequest.Header.Add("user-agent", "pulsar-heartbeat")
-	newRequest.Header.Add("Authorization", "Bearer "+token)
+	if tokenSupplier != nil {
+		token, err := tokenSupplier()
+		if err != nil {
+			return nil, err
+		}
+		newRequest.Header.Add("Authorization", "Bearer "+token)
+	}
 	client := &http.Client{
 		CheckRedirect: util.PreserveHeaderForRedirect,
 		Timeout:       10 * time.Second,
@@ -152,7 +158,7 @@ func BrokerTopicsQuery(brokerBaseURL, token string) ([]string, error) {
 }
 
 // ConnectBrokerHealthcheckTopic reads the latest messages off broker's healthcheck topic
-func ConnectBrokerHealthcheckTopic(brokerURL, clusterName, pulsarURL, token string, completeChan chan error) {
+func ConnectBrokerHealthcheckTopic(brokerURL, clusterName, pulsarURL string, tokenSupplier func()(string,error), completeChan chan error) {
 	// "persistent://pulsar/{cluster}/10.244.7.85:8080/healthcheck"
 	brokerAddr := util.SingleSlashJoin(strings.ReplaceAll(brokerURL, "http://", ""), "healthcheck")
 	defer func() {
@@ -161,7 +167,7 @@ func ConnectBrokerHealthcheckTopic(brokerURL, clusterName, pulsarURL, token stri
 			log.Errorf("cluster %s individual broker %s test timed out", clusterName, brokerAddr)
 		}
 	}()
-	client, err := GetPulsarClient(pulsarURL, token)
+	client, err := GetPulsarClient(pulsarURL, tokenSupplier)
 	if err != nil {
 		completeChan <- err
 		return
@@ -201,8 +207,8 @@ func ConnectBrokerHealthcheckTopic(brokerURL, clusterName, pulsarURL, token stri
 }
 
 // EvaluateBrokers evaluates all brokers' health
-func EvaluateBrokers(urlPrefix, clusterName, pulsarURL, token string, duration time.Duration) (int, error) {
-	brokers, err := GetBrokers(urlPrefix, clusterName, token)
+func EvaluateBrokers(urlPrefix, clusterName, pulsarURL string, tokenSupplier func()(string,error), duration time.Duration) (int, error) {
+	brokers, err := GetBrokers(urlPrefix, clusterName, tokenSupplier)
 	if err != nil {
 		return 0, err
 	}
@@ -215,7 +221,7 @@ func EvaluateBrokers(urlPrefix, clusterName, pulsarURL, token string, duration t
 	defer close(completeChan)
 
 	for _, brokerURL := range brokers {
-		go ConnectBrokerHealthcheckTopic(brokerURL, clusterName, pulsarURL, token, completeChan)
+		go ConnectBrokerHealthcheckTopic(brokerURL, clusterName, pulsarURL, tokenSupplier, completeChan)
 	}
 
 	receivedCounter := 0
@@ -251,13 +257,13 @@ func TestBrokers(topicCfg TopicCfg) error {
 	}
 	name := topicCfg.ClusterName + "-brokers"
 
-	token := util.AssignString(topicCfg.Token, GetConfig().Token)
+	tokenSupplier := util.TokenSupplierWithOverride(topicCfg.Token, Config.TokenSupplier())
 
 	intervalDuration := 10 * time.Second
 	if topicCfg.IntervalSeconds > 20 {
 		intervalDuration = time.Duration(topicCfg.IntervalSeconds/2) * time.Second
 	}
-	failedBrokers, err := EvaluateBrokers(topicCfg.AdminURL, topicCfg.ClusterName, topicCfg.PulsarURL, token, intervalDuration)
+	failedBrokers, err := EvaluateBrokers(topicCfg.AdminURL, topicCfg.ClusterName, topicCfg.PulsarURL, tokenSupplier, intervalDuration)
 
 	if failedBrokers > 0 {
 		errMsg := fmt.Sprintf("cluster %s has %d unhealthy brokers, error message: %v", name, failedBrokers, err)

--- a/src/cfg/config.go
+++ b/src/cfg/config.go
@@ -192,7 +192,7 @@ type Configuration struct {
 	tokenFunc		func()(string, error)
 }
 
-func (c Configuration) Init() {
+func (c *Configuration) Init() {
 	if len(c.Name) < 1 {
 		panic("a valid `name` in Configuration must be specified")
 	}
@@ -225,7 +225,7 @@ func (c Configuration) Init() {
 	}
 }
 
-func (c Configuration) TokenSupplier() func() (string, error) {
+func (c *Configuration) TokenSupplier() func() (string, error) {
 	return c.tokenFunc
 }
 

--- a/src/cfg/pulsar-admin.go
+++ b/src/cfg/pulsar-admin.go
@@ -83,7 +83,7 @@ func PulsarAdminTenant(clusterURL string, tokenSupplier func()(string,error)) (i
 // PulsarTenants get a list of tenants on each cluster
 func PulsarTenants() {
 	clusters := GetConfig().PulsarAdminConfig.Clusters
-	tokenSupplier := util.TokenSupplierWithOverride(GetConfig().PulsarAdminConfig.Token, Config.TokenSupplier())
+	tokenSupplier := util.TokenSupplierWithOverride(GetConfig().PulsarAdminConfig.Token, GetConfig().TokenSupplier())
 
 	for _, cluster := range clusters {
 		adminURL, err := url.ParseRequestURI(cluster.URL)

--- a/src/cfg/pulsar-latency.go
+++ b/src/cfg/pulsar-latency.go
@@ -265,7 +265,7 @@ func TestTopicLatency(topicCfg TopicCfg) {
 		panic(err) //panic because this is a showstopper
 	}
 	clusterName := adminURL.Hostname()
-	tokenSupplier := util.TokenSupplierWithOverride(topicCfg.Token, Config.TokenSupplier())
+	tokenSupplier := util.TokenSupplierWithOverride(topicCfg.Token, GetConfig().TokenSupplier())
 
 	if topicCfg.NumberOfPartitions < 2 {
 		testTopicLatency(clusterName, tokenSupplier, topicCfg)

--- a/src/cfg/websocket.go
+++ b/src/cfg/websocket.go
@@ -199,7 +199,7 @@ func WsLatencyTest(producerURL, subscriptionURL string, tokenSupplier func()(str
 
 // TestWsLatency test all clusters' websocket pub sub latency
 func TestWsLatency(config WsConfig) {
-	tokenSupplier := util.TokenSupplierWithOverride(config.Token, Config.TokenSupplier())
+	tokenSupplier := util.TokenSupplierWithOverride(config.Token, GetConfig().TokenSupplier())
 	expectedLatency := util.TimeDuration(config.LatencyBudgetMs, 2*latencyBudget, time.Millisecond)
 
 	stdVerdict := util.GetStdBucket(config.Cluster)

--- a/src/cfg/websocket.go
+++ b/src/cfg/websocket.go
@@ -83,9 +83,15 @@ func tokenAsURLQueryParam(url, token string) string {
 }
 
 // WsLatencyTest latency test for websocket
-func WsLatencyTest(producerURL, subscriptionURL, token string) (MsgResult, error) {
+func WsLatencyTest(producerURL, subscriptionURL string, tokenSupplier func()(string,error)) (MsgResult, error) {
 	wsHeaders := http.Header{}
-	if token != "" {
+	token := ""
+	var err error
+	if tokenSupplier != nil {
+		token, err = tokenSupplier()
+		if err != nil {
+			return MsgResult{Latency: failedLatency}, err
+		}
 		bearerToken := "Bearer " + token
 		wsHeaders.Add("Authorization", bearerToken)
 	}
@@ -193,12 +199,12 @@ func WsLatencyTest(producerURL, subscriptionURL, token string) (MsgResult, error
 
 // TestWsLatency test all clusters' websocket pub sub latency
 func TestWsLatency(config WsConfig) {
-	token := util.AssignString(config.Token, GetConfig().Token)
+	tokenSupplier := util.TokenSupplierWithOverride(config.Token, Config.TokenSupplier())
 	expectedLatency := util.TimeDuration(config.LatencyBudgetMs, 2*latencyBudget, time.Millisecond)
 
 	stdVerdict := util.GetStdBucket(config.Cluster)
 
-	result, err := WsLatencyTest(config.ProducerURL, config.ConsumerURL, token)
+	result, err := WsLatencyTest(config.ProducerURL, config.ConsumerURL, tokenSupplier)
 	if err != nil {
 		errMsg := fmt.Sprintf("cluster %s, %s websocket latency test Pulsar error: %v", config.Cluster, config.Name, err)
 		log.Errorf(errMsg)

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -95,6 +95,15 @@ func AssignString(values ...string) string {
 	return ""
 }
 
+func TokenSupplierWithOverride(token string, supplier func()(string, error)) func()(string, error) {
+	if token != "" {
+		return func()(string, error) {
+			return token, nil
+		}
+	}
+	return supplier
+}
+
 // ReportError logs error
 func ReportError(err error) error {
 	log.Printf("error %v", err)


### PR DESCRIPTION
**Background**
heartbeat supports providing a static JWT token for authentication to be presented to pulsar cluster over http protocol (rest-apis) or pulsar protocol (produce/consume). Precedence followed as of today is
`StaticToken in ComponentConfig > StaticToken in GlobalConfig`
Here ComponentConfig are TopicCfg, WsConfig, PulsarAdminRESTCfg. GlobalConfig is `Configuration` object. 

**Motivation**
Static tokens are a security risk and often pulsar clusters are deployed with authentication providers where permanent tokens cannot be issued. This was the case for us as well. OAuth2 is a popular protocol and client credentials flow is commonly used to get tokens issued from the provider with a fixed expiry. 

**Feature**
This PR adds support for optionally fetching tokens from any OAuth2 provider and using the same when interacting with Pulsar cluster. It uses golang oauth2 lib which manages expiry and refresh of tokens automatically. The new token precedence order is
`StaticToken in ComponentConfig > DynamicToken using provider specified in GlobalConfig > StaticToken in GlobalConfig`

This change is backwards-compatible.