### PR TITLE
optimize docker build to cache dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -109,4 +109,4 @@ jobs:
       - name: Build Docker Image
         run: |
           pwd
-          sudo docker build -t pulsar-heartbeat .
+          sudo DOCKER_BUILDKIT=1 docker build -t pulsar-heartbeat .

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: push
 #
 # Docker tag with v prefix to differentiate the official release build, triggered by git tagging
 #
-TAG ?= v0.0.7
+TAG ?= latest
 PREFIX ?= datastax/pulsar-heartbeat
 BUILD_DIR ?= bin
 


### PR DESCRIPTION
Update the Dockerfile to cache the go module dependencies. Previously, the container build would re-download all modules for every build of the container.  With this change, the dependency modules will only be downloaded if go.mod or go.sum changes.

This change also caches intermediate go build files to speed up rebuild time.