### PR TITLE
fix websocket latency test log errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/gops v0.3.10
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-retryablehttp v0.6.4
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	k8s.io/api v0.18.5
@@ -51,6 +50,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/src/cfg/config.go
+++ b/src/cfg/config.go
@@ -279,12 +279,11 @@ func hasPrefix(buf []byte, prefix []byte) bool {
 	return bytes.HasPrefix(trim, prefix)
 }
 
-//GetConfig returns a reference to the Configuration
+// GetConfig returns a reference to the Configuration
 func GetConfig() *Configuration {
 	return &Config
 }
 
-//
 type monitorFunc func()
 
 // RunInterval runs interval

--- a/src/main.go
+++ b/src/main.go
@@ -70,7 +70,7 @@ func main() {
 	cfg.PushToPrometheusProxyThread()
 
 	if config.PrometheusConfig.ExposeMetrics {
-		log.Infof("start to listen to http port %s", config.PrometheusConfig.Port)
+		log.Infof("serving metrics on port %s", config.PrometheusConfig.Port)
 		http.Handle("/metrics", promhttp.Handler())
 		http.ListenAndServe(util.AssignString(config.PrometheusConfig.Port, ":8089"), nil)
 	}


### PR DESCRIPTION
The logs are producing this error on every web socket test.
```
2022/12/05 08:11:02 error decode producer response error: illegal base64 data at input byte 0
```
This is caused by attempting to read the producer ack value as base64 encoded instead of a JSON string.

Also includes some minor improvements to error handling.