### PR TITLE
Upgrade build image to debian:11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # multi-stage build
-FROM debian:9 AS proot
+FROM debian:11 AS proot
 RUN apt-get update && apt-get install -q -y build-essential git libseccomp-dev libtalloc-dev \
  # deps for PERSISTENT_CHOWN extension
  libprotobuf-c-dev libattr1-dev


### PR DESCRIPTION
The build is failing with the following error:

```
#9 1.395 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
#9 1.396 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
#9 1.396 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.130.132 80]
#9 1.396 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
executor failed running [/bin/sh -c apt-get update && apt-get install -q -y build-essential git libseccomp-dev libtalloc-dev  libprotobuf-c-dev libattr1-dev]: exit code: 100
make: *** [container] Error 1
```

Upgrading the build image to `debian:11` appears to fix the issue.