### PR TITLE
fix index out of range when zk or bk replicas are 0

### DIFF
--- a/src/k8s/clientset.go
+++ b/src/k8s/clientset.go
@@ -215,13 +215,21 @@ func (c *Client) UpdateReplicas(namespace string) error {
 	if err != nil {
 		return err
 	}
-	c.Zookeeper.Replicas = *(zk.Items[0]).Spec.Replicas
+	if len(zk.Items) > 0 {
+		c.Zookeeper.Replicas = *(zk.Items[0]).Spec.Replicas
+	} else {
+		c.Zookeeper.Replicas = 0
+	}
 
 	bk, err := c.getStatefulSets(namespace, BookkeeperSts)
 	if err != nil {
 		return err
 	}
-	c.Bookkeeper.Replicas = *(bk.Items[0]).Spec.Replicas
+	if len(bk.Items) > 0 {
+		c.Bookkeeper.Replicas = *(bk.Items[0]).Spec.Replicas
+	} else {
+		c.Bookkeeper.Replicas = 0
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes this issue:
```
023/09/05 19:44:14  info this is an in-cluster k8s monitor, pulsar namespace pulsar
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/datastax/pulsar-heartbeat/src/k8s.(*Client).UpdateReplicas(0xc000461450, {0xc0001b6440, 0x6})
	/root/src/k8s/clientset.go:218 +0x275
github.com/datastax/pulsar-heartbeat/src/k8s.GetK8sClient({0xc0001b6440, 0x6})
	/root/src/k8s/clientset.go:162 +0x32e
github.com/datastax/pulsar-heartbeat/src/cfg.MonitorK8sPulsarCluster()
	/root/src/cfg/cluster-monitor.go:102 +0x127
main.main()
	/root/src/main.go:60 +0x1f9
```