### PR TITLE
Fix Name of Pulsar

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Here is a list of features that Pulsar Heartbeat supports.
 - [x] monitor multiple Pulsar clusters (with no kubernetes pods monitoring)
 - [x] co-resident monitoring within the same Pulsar Kubernetes cluster
 
-This is a data driven tool that sources configuration from a yaml or json file. Here is a [template](config/runtime_template.yml).
+This is a data driven tool that sources configuration from a yaml or json file. Here is a [template](config/runtime-template.yml).
 The configuration json file can be specified in the overwrite order of
 - an environment variable `PULSAR_OPS_MONITOR_CFG`
 - an command line argument `./pulsar-heartbeat -config /path/to/pulsar_ops_monitor_config.yml`

--- a/src/cfg/metrics.go
+++ b/src/cfg/metrics.go
@@ -67,7 +67,7 @@ func TenantsGaugeOpt() prometheus.GaugeOpts {
 		Namespace: "pulsar",
 		Subsystem: "tenant",
 		Name:      "size",
-		Help:      "Plusar rest api tenant counts",
+		Help:      "Pulsar rest api tenant counts",
 	}
 }
 
@@ -127,7 +127,7 @@ func FuncLatencyGaugeOpt() prometheus.GaugeOpts {
 		Namespace: "pulsar",
 		Subsystem: "function",
 		Name:      "latency_ms",
-		Help:      "Plusar message latency in ms",
+		Help:      "Pulsar message latency in ms",
 	}
 }
 
@@ -202,14 +202,14 @@ func getMetricKey(opt prometheus.GaugeOpts) string {
 // GetGaugeType get the Prometheus Gauge Option based on type/subsystem
 func GetGaugeType(nameType string) prometheus.GaugeOpts {
 	if nameType == funcTopicSubsystem || strings.HasPrefix(nameType, "func_topic") {
-		return MsgLatencyGaugeOpt(funcTopicSubsystem, "Plusar function input output topic latency in ms")
+		return MsgLatencyGaugeOpt(funcTopicSubsystem, "Pulsar function input output topic latency in ms")
 	}
 
 	if nameType == websocketSubsystem {
-		return MsgLatencyGaugeOpt(websocketSubsystem, "Plusar websocket pubsub topic latency in ms")
+		return MsgLatencyGaugeOpt(websocketSubsystem, "Pulsar websocket pubsub topic latency in ms")
 	}
 
-	return MsgLatencyGaugeOpt(pubSubSubsystem, "Plusar pubsub message latency in ms")
+	return MsgLatencyGaugeOpt(pubSubSubsystem, "Pulsar pubsub message latency in ms")
 }
 
 // GetOfflinePodsCounter returns prometheus GaugeOpts for kubernetes cluster pod offline counter


### PR DESCRIPTION
* The name for `pulsar` is not set correctly in various places around metrics. This fixes the name
* Also the path the config file was not set correctly. This fixes the path.