### PR TITLE
[bugfix]added-new-flag-to-suppress-alerts-websocket-test-topic

### DIFF
--- a/src/cfg/config.go
+++ b/src/cfg/config.go
@@ -149,6 +149,10 @@ type WsConfig struct {
 	Subscription    string         `json:"subscription"`
 	URLQueryParams  string         `json:"urlQueryParams"`
 	AlertPolicy     AlertPolicyCfg `json:"AlertPolicy"`
+	// SuppressAlertsOnTopicNotFound when true, logs the failure but does not
+	// raise an incident. Use this for transient or test topics that may not
+	// always exist (e.g. incluster-websocket-latency-test in dev clusters).
+	SuppressAlertsOnTopicNotFound bool `json:"suppressAlertsOnTopicNotFound"`
 }
 
 // K8sClusterCfg is configuration to monitor kubernete cluster

--- a/src/cfg/websocket.go
+++ b/src/cfg/websocket.go
@@ -221,7 +221,9 @@ func TestWsLatency(config WsConfig) {
 	if err != nil {
 		errMsg := fmt.Sprintf("cluster %s, %s websocket latency test Pulsar error: %v", config.Cluster, config.Name, err)
 		log.Errorf(errMsg)
-		ReportIncident(config.Name, config.Cluster, "websocket persisted latency test failure", errMsg, &config.AlertPolicy)
+		if !config.SuppressAlertsOnTopicNotFound {
+			ReportIncident(config.Name, config.Cluster, "websocket persisted latency test failure", errMsg, &config.AlertPolicy)
+		}
 	} else if result.Latency > expectedLatency {
 		stdVerdict.Add(float64(result.Latency.Milliseconds()))
 		errMsg := fmt.Sprintf("cluster %s, %s websocket test message latency %v over the budget %v",


### PR DESCRIPTION
In dev/staging clusters, incluster-websocket-latency-test is a transient test topic that may not always exist. When absent, the websocket handshake fails and triggers a false-positive pager escalation.

Solution
Added a per-entry boolean field suppressAlertsOnTopicNotFound to WsConfig. When true, connection failures are logged but no incident is raised. Latency-over-budget failures are unaffected and still alert normally.

Changes
src/cfg/config.go — new SuppressAlertsOnTopicNotFound field on WsConfig
src/cfg/websocket.go — guard ReportIncident behind the flag in TestWsLatency()
Usage
pulsarWebSocketConfigs:
  - name: "incluster-websocket-topic"
    suppressAlertsOnTopicNotFound: true  # dev/staging only

Defaults to false — no behaviour change for existing configurations.